### PR TITLE
fix build with current versions of folly and glfw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ data
 .idea
 .cproject
 .project
+CMakeLists.txt.user
 
 # MAC files
 .DS_STORE
@@ -22,3 +23,4 @@ KinectLog.txt
 
 # Python compiled files.
 *.pyc
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ INCLUDE_DIRECTORIES(${OpenGL_INCLUDE_DIRS})
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     SET(GL_LIBRARIES
         dl
-        glfw3
+        glfw
         X11
         Xcursor
         Xrandr

--- a/master/MasterApplication.cc
+++ b/master/MasterApplication.cc
@@ -112,7 +112,7 @@ int MasterApplication::run() {
 
     // Write the calibration data to .calibrate.
     std::ofstream(calibFile.string())
-        << folly::toJson(system_->toJSON()).toStdString()
+        << folly::toJson(system_->toJSON())
         << std::endl;
   } else {
     std::cout << "Loading calibration data..." << std::endl;

--- a/master/ProCamSystem.cc
+++ b/master/ProCamSystem.cc
@@ -43,7 +43,7 @@ cv::Mat loadMat(
 }
 
 folly::dynamic saveMat(const cv::Mat &mat) {
-  folly::dynamic arr = {};
+  folly::dynamic arr = folly::dynamic::array;
 
   switch (mat.type()) {
     case CV_32FC1: {
@@ -97,7 +97,7 @@ void ProCamSystem::fromJSON(const folly::dynamic &data) {
   for (const auto &key : data.keys()) {
     const auto &cd = data[key];
     addProCam(
-        std::stoi(key.asString().toStdString()),
+        std::stoi(key.asString()),
         {
           loadMat<float, 1>(3, 3, cd["color-cam"]["proj"]),
           loadMat<float, 1>(0, 0, cd["color-cam"]["dist"]),

--- a/test/ProCamSystemTest.cc
+++ b/test/ProCamSystemTest.cc
@@ -26,7 +26,7 @@ enum class MatType {
 };
 
 folly::dynamic genJsonMat(int height, int width, int depth) {
-  folly::dynamic mat = {};
+  folly::dynamic mat = folly::dynamic::array;
   for (int i = 0; i < height; ++i) {
     for (int j = 0; j < width; ++j) {
       for (int k = 0; k < depth; ++k) {


### PR DESCRIPTION
correct linker flag for glfw on linux (-lglfw for libglfw.so.3)
remove toStdString as toJson is already a standard string
initialize folly dynamics as array instead of null
folly was built using boost 1.62.0